### PR TITLE
Fixed layout of matrices when passed between C++ and Python.

### DIFF
--- a/src/scranpy/analyze.py
+++ b/src/scranpy/analyze.py
@@ -173,7 +173,7 @@ class AnalyzeResults:
         sce.colData["clusters"] = self.clustering.clusters
 
         sce.reducedDims = {
-            "pca": self.dimensionality_reduction.pca.principal_components.T,
+            "pca": self.dimensionality_reduction.pca.principal_components,
             "tsne": array(
                 [
                     self.dimensionality_reduction.tsne.x,

--- a/src/scranpy/clustering/build_snn_graph.py
+++ b/src/scranpy/clustering/build_snn_graph.py
@@ -82,8 +82,8 @@ def build_snn_graph(
             Object containing per-cell nearest neighbor results or data that can be used to derive them.
 
             This may be a a 2-dimensional :py:class:`~numpy.ndarray` containing per-cell
-            coordinates, where rows are features/dimensions and columns are
-            cells. This is most typically the result of the PCA step
+            coordinates, where rows are cells and columns are dimensions.
+            This is most typically the result of the PCA step
             (:py:meth:`~scranpy.dimensionality_reduction.run_pca.run_pca`).
 
             Alternatively, ``input`` may be a pre-built neighbor search index

--- a/src/scranpy/dimensionality_reduction/run_tsne.py
+++ b/src/scranpy/dimensionality_reduction/run_tsne.py
@@ -145,8 +145,8 @@ def initialize_tsne(
             Object containing per-cell nearest neighbor results or data that can be used to derive them.
 
             This may be a a 2-dimensional :py:class:`~numpy.ndarray` containing per-cell
-            coordinates, where rows are features/dimensions and columns are
-            cells. This is most typically the result of
+            coordinates, where rows are cells and columns are dimensions.
+            This is most typically the result of
             :py:meth:`~scranpy.dimensionality_reduction.run_pca.run_pca`.
 
             Alternatively, ``input`` may be a pre-built neighbor search index
@@ -236,8 +236,8 @@ def run_tsne(
             Object containing per-cell nearest neighbor results or data that can be used to derive them.
 
             This may be a a 2-dimensional :py:class:`~numpy.ndarray` containing per-cell
-            coordinates, where rows are features/dimensions and columns are
-            cells. This is most typically the result of
+            coordinates, where rows are cells and columns are features/dimensions.
+            This is most typically the result of
             :py:meth:`~scranpy.dimensionality_reduction.run_pca.run_pca`.
 
             Alternatively, ``input`` may be a pre-built neighbor search index

--- a/src/scranpy/dimensionality_reduction/run_umap.py
+++ b/src/scranpy/dimensionality_reduction/run_umap.py
@@ -166,8 +166,8 @@ def initialize_umap(
             Object containing per-cell nearest neighbor results or data that can be used to derive them.
 
             This may be a a 2-dimensional :py:class:`~numpy.ndarray` containing per-cell
-            coordinates, where rows are features/dimensions and columns are
-            cells. This is most typically the result of
+            coordinates, where rows are cells and columns are dimensions. 
+            This is most typically the result of
             :py:meth:`~scranpy.dimensionality_reduction.run_pca.run_pca`.
 
             Alternatively, ``input`` may be a pre-built neighbor search index
@@ -248,8 +248,8 @@ def run_umap(
             Object containing per-cell nearest neighbor results or data that can be used to derive them.
 
             This may be a a 2-dimensional :py:class:`~numpy.ndarray` containing per-cell
-            coordinates, where rows are features/dimensions and columns are
-            cells. This is most typically the result of
+            coordinates, where rows are cells and columns are features/dimensions.
+            This is most typically the result of
             :py:meth:`~scranpy.dimensionality_reduction.run_pca.run_pca`.
 
             Alternatively, ``input`` may be a pre-built neighbor search index

--- a/src/scranpy/nearest_neighbors/build_neighbor_index.py
+++ b/src/scranpy/nearest_neighbors/build_neighbor_index.py
@@ -72,8 +72,8 @@ def build_neighbor_index(
     :py:meth:`~scranpy.nearest_neighbors.find_nearest_neighbors.find_nearest_neighbors`.
 
     Args:
-        input (ndarray): A matrix where rows are dimensions and cells are columns.
-            This is usually the principal components from the
+        input (ndarray): A matrix where rows are cells and dimensions are columns.
+            This is usually the principal components matrix from 
             :py:meth:`~scranpy.dimensionality_reduction.run_pca.run_pca`.
         options (BuildNeighborIndexOptions): Optional parameters.
 
@@ -83,7 +83,10 @@ def build_neighbor_index(
     if options.verbose is True:
         logger.info("Building nearest neighbor index...")
 
+    if not input.flags.C_CONTIGUOUS:
+        raise ValueError("expected 'input' to have row-major layout")
+
     ptr = lib.build_neighbor_index(
-        input.shape[0], input.shape[1], input, options.approximate
+        input.shape[1], input.shape[0], input, options.approximate
     )
     return NeighborIndex(ptr)

--- a/src/scranpy/nearest_neighbors/build_neighbor_index.py
+++ b/src/scranpy/nearest_neighbors/build_neighbor_index.py
@@ -83,7 +83,7 @@ def build_neighbor_index(
     if options.verbose is True:
         logger.info("Building nearest neighbor index...")
 
-    if not input.flags.C_CONTIGUOUS:
+    if not input.flags.c_contiguous:
         raise ValueError("expected 'input' to have row-major layout")
 
     ptr = lib.build_neighbor_index(

--- a/src/scranpy/nearest_neighbors/find_nearest_neighbors.py
+++ b/src/scranpy/nearest_neighbors/find_nearest_neighbors.py
@@ -104,7 +104,7 @@ class NeighborResults:
         nobs = lib.fetch_neighbor_results_nobs(self.__ptr)
         k = lib.fetch_neighbor_results_k(self.__ptr)
 
-        # C++ stores this data as column-major, but NumPy defaults to 
+        # C++ stores this data as column-major k*nobs, but NumPy defaults to 
         # row-major, so we just flip the dimensions to keep everyone happy.
         out_i = ndarray((nobs, k), dtype=int32)
         out_d = ndarray((nobs, k), dtype=float64)
@@ -124,13 +124,13 @@ class NeighborResults:
             NeighborResults: Instance of this class, constructed from the data in ``content``.
         """
         idx = content.index
-        if idx.flags.c_contiguous:
+        if not idx.flags.c_contiguous:
             raise ValueError("expected 'content.index' to have a row-major layout")
 
         dist = content.distance
         if dist.shape != idx.shape: 
             raise ValueError("expected 'content.distance' and 'content.index' to have the same shape")
-        if dist.flags.c_contiguous:
+        if not dist.flags.c_contiguous:
             raise ValueError("expected 'content.index' to have a row-major layout")
 
         ptr = lib.unserialize_neighbor_results(idx.shape[0], idx.shape[1], idx, dist)

--- a/src/scranpy/nearest_neighbors/find_nearest_neighbors.py
+++ b/src/scranpy/nearest_neighbors/find_nearest_neighbors.py
@@ -103,8 +103,12 @@ class NeighborResults:
         """
         nobs = lib.fetch_neighbor_results_nobs(self.__ptr)
         k = lib.fetch_neighbor_results_k(self.__ptr)
-        out_i = ndarray((k, nobs), dtype=int32)
-        out_d = ndarray((k, nobs), dtype=float64)
+
+        # C++ stores this data as column-major, but NumPy defaults to 
+        # row-major, so we just flip the dimensions to keep everyone happy.
+        out_i = ndarray((nobs, k), dtype=int32)
+        out_d = ndarray((nobs, k), dtype=float64)
+
         lib.serialize_neighbor_results(self.__ptr, out_i, out_d)
         return SerializedNeighborResults(out_i, out_d)
 
@@ -120,7 +124,15 @@ class NeighborResults:
             NeighborResults: Instance of this class, constructed from the data in ``content``.
         """
         idx = content.index
+        if idx.flags.C_CONTIGUOUS:
+            raise ValueError("expected 'content.index' to have a row-major layout")
+
         dist = content.distance
+        if dist.shape != idx.shape: 
+            raise ValueError("expected 'content.distance' and 'content.index' to have the same shape")
+        if dist.flags.C_CONTIGUOUS:
+            raise ValueError("expected 'content.index' to have a row-major layout")
+
         ptr = lib.unserialize_neighbor_results(idx.shape[0], idx.shape[1], idx, dist)
         return cls(ptr)
 

--- a/src/scranpy/nearest_neighbors/find_nearest_neighbors.py
+++ b/src/scranpy/nearest_neighbors/find_nearest_neighbors.py
@@ -124,13 +124,13 @@ class NeighborResults:
             NeighborResults: Instance of this class, constructed from the data in ``content``.
         """
         idx = content.index
-        if idx.flags.C_CONTIGUOUS:
+        if idx.flags.c_contiguous:
             raise ValueError("expected 'content.index' to have a row-major layout")
 
         dist = content.distance
         if dist.shape != idx.shape: 
             raise ValueError("expected 'content.distance' and 'content.index' to have the same shape")
-        if dist.flags.C_CONTIGUOUS:
+        if dist.flags.c_contiguous:
             raise ValueError("expected 'content.index' to have a row-major layout")
 
         ptr = lib.unserialize_neighbor_results(idx.shape[0], idx.shape[1], idx, dist)

--- a/tests/data/mock_data.py
+++ b/tests/data/mock_data.py
@@ -6,8 +6,8 @@ __license__ = "MIT"
 
 x = np.random.rand(1000, 100)
 
-# PCs in rows, cells in dimensions
-pcs = np.random.rand(50, 1000)  
+# PCs in columns, cells in rows
+pcs = np.random.rand(1000, 25)  
 
 block_levels = ["A", "B", "C"]
 block = []

--- a/tests/test_dimreds.py
+++ b/tests/test_dimreds.py
@@ -20,7 +20,7 @@ def test_run_tsne(mock_data):
 
     assert isinstance(out, TsneEmbedding)
     assert out.x.shape[0] == out.y.shape[0]
-    assert out.x.shape[0] == y.shape[1]
+    assert out.x.shape[0] == y.shape[0]
 
     # Same results with multiple threads.
     outp = run_tsne(
@@ -37,7 +37,7 @@ def test_run_umap(mock_data):
 
     assert isinstance(out, UmapEmbedding)
     assert out.x.shape[0] == out.y.shape[0]
-    assert out.x.shape[0] == y.shape[1]
+    assert out.x.shape[0] == y.shape[0]
 
     # Same results with multiple threads.
     outp = run_umap(

--- a/tests/test_nearest_neighbors.py
+++ b/tests/test_nearest_neighbors.py
@@ -15,11 +15,11 @@ __license__ = "MIT"
 def test_neighbors(mock_data):
     y = mock_data.pcs
     idx = build_neighbor_index(y, BuildNeighborIndexOptions(approximate=False))
-    assert idx.num_cells() == 1000
-    assert idx.num_dimensions() == 50
+    assert idx.num_cells() == y.shape[0]
+    assert idx.num_dimensions() == y.shape[1]
 
     res = find_nearest_neighbors(idx, k=10)
-    assert res.num_cells() == 1000
+    assert res.num_cells() == y.shape[0]
     assert res.num_neighbors() == 10
     assert isinstance(res.get(2), SingleNeighborResults)
 

--- a/tests/test_snn_graph.py
+++ b/tests/test_snn_graph.py
@@ -16,6 +16,7 @@ def test_build_snn_graph(mock_data):
 
     assert clustering is not None
     assert clustering.membership is not None
+    assert len(clustering.membership) == y.shape[0]
 
     # Same results in parallel.
     outp = build_snn_graph(y, options=BuildSnnGraphOptions(num_threads=3))


### PR DESCRIPTION
The former (Eigen) assumes a column-major dim*cell matrix, while the latter (NumPy) is typically row-major; so to avoid having to do an actual transposition, we make the latter a row-major cell*dim matrix, which allows us to keep the same memory layout when moving data across.