### PR TITLE
Optionally return size factors from log_norm_counts.

### DIFF
--- a/src/scranpy/analyze/AnalyzeOptions.py
+++ b/src/scranpy/analyze/AnalyzeOptions.py
@@ -56,10 +56,6 @@ class AnalyzeOptions:
         filter_cells_options (FilterCellsOptions):
             Options to pass to :py:meth:`~scranpy.quality_control.filter_cells.filter_cells`.
 
-        center_size_factors_options (CenterSizeFactorsOptions):
-            Options to pass to :py:meth:`~scranpy.normalization.center_size_factors.center_size_factors`.
-            Ignored if ``log_norm_counts_options.size_factors`` is set.
-
         log_norm_counts_options (LogNormCountsOptions):
             Options to pass to :py:meth:`~scranpy.normalization.log_norm_counts.log_norm_counts`.
 
@@ -111,10 +107,6 @@ class AnalyzeOptions:
 
     filter_cells_options: qc.FilterCellsOptions = field(
         default_factory=qc.FilterCellsOptions
-    )
-
-    center_size_factors_options: norm.CenterSizeFactorsOptions = field(
-        default_factory=norm.CenterSizeFactorsOptions
     )
 
     log_norm_counts_options: norm.LogNormCountsOptions = field(
@@ -189,7 +181,6 @@ class AnalyzeOptions:
         self.suggest_rna_qc_filters_options.set_verbose(verbose)
         self.create_rna_qc_filter_options.set_verbose(verbose)
         self.filter_cells_options.set_verbose(verbose)
-        self.center_size_factors_options.set_verbose(verbose)
         self.log_norm_counts_options.set_verbose(verbose)
         self.choose_hvgs_options.set_verbose(verbose)
         self.model_gene_variances_options.set_verbose(verbose)

--- a/src/scranpy/analyze/live_analyze.py
+++ b/src/scranpy/analyze/live_analyze.py
@@ -77,19 +77,23 @@ def live_analyze(
         filtered_block = None
 
     if options.log_norm_counts_options.size_factors is None:
-        results.size_factors = norm.center_size_factors(
-            results.rna_quality_control_metrics.column("sums")[keep],
-            options=update(options.center_size_factors_options, block=filtered_block),
-        )
+        raw_size_factors = results.rna_quality_control_metrics.column("sums")[keep]
     else:
-        results.size_factors = options.log_norm_counts_options.size_factors[keep]
+        raw_size_factors = options.log_norm_counts_options.size_factors
 
-    normed = norm.log_norm_counts(
-        filtered,
+    normed, final_size_factors = norm.log_norm_counts(filtered, 
         options=update(
-            options.log_norm_counts_options, size_factors=results.size_factors
-        ),
+            options.log_norm_counts_options,
+            size_factors=raw_size_factors,
+            center_size_factors_options=update(
+                options.log_norm_counts_options.center_size_factors_options,
+                block=filtered_block
+            ),
+            with_size_factors=True
+        )
     )
+
+    results.size_factors = final_size_factors
 
     results.gene_variances = feat.model_gene_variances(
         normed,

--- a/src/scranpy/analyze/live_analyze.py
+++ b/src/scranpy/analyze/live_analyze.py
@@ -81,16 +81,17 @@ def live_analyze(
     else:
         raw_size_factors = options.log_norm_counts_options.size_factors
 
-    normed, final_size_factors = norm.log_norm_counts(filtered, 
+    normed, final_size_factors = norm.log_norm_counts(
+        filtered,
         options=update(
             options.log_norm_counts_options,
             size_factors=raw_size_factors,
             center_size_factors_options=update(
                 options.log_norm_counts_options.center_size_factors_options,
-                block=filtered_block
+                block=filtered_block,
             ),
-            with_size_factors=True
-        )
+            with_size_factors=True,
+        ),
     )
 
     results.size_factors = final_size_factors

--- a/src/scranpy/normalization/log_norm_counts.py
+++ b/src/scranpy/normalization/log_norm_counts.py
@@ -76,7 +76,7 @@ def log_norm_counts(input, options: LogNormCountsOptions = LogNormCountsOptions(
         directly returned. This is either a :py:class:`~mattress.TatamiNumericPointer`,
         if ``input`` is also a :py:class:`~mattress.TatamiNumericPointer`; as a
         :py:class:`~delayedarray.DelayedArray`, if ``input`` is array-like and
-        ``delayed = True``; or otherwise, an object of the same type as ``input``. 
+        ``delayed = True``; or otherwise, an object of the same type as ``input``.
 
         If `options.with_size_factors = True`, a 2-tuple is returned containing
         the log-normalized matrix and an array of (possibly centered) size factors.

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -1,6 +1,8 @@
 from scranpy import AnalyzeResults, analyze, AnalyzeOptions, MiscellaneousOptions
+from scranpy.normalization import LogNormCountsOptions
 from singlecellexperiment import SingleCellExperiment
 import delayedarray as da
+import numpy as np
 
 __author__ = "jkanche"
 __copyright__ = "jkanche"
@@ -24,6 +26,21 @@ def test_analyze(mock_data):
 
     dry = analyze(None, None, dry_run=True)
     assert isinstance(dry, str)
+
+
+def test_analyze_size_factors(mock_data):
+    x = mock_data.x
+    out = analyze(
+        x, 
+        features=[f"{i}" for i in range(1000)],
+        options=AnalyzeOptions(
+            log_norm_counts_options=LogNormCountsOptions(
+                size_factors=np.ones(x.shape[1])
+            )
+        )
+    )
+
+    assert (out.size_factors == np.ones(x.shape[1])).all()
 
 
 def test_analyze_blocked(mock_data):

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -31,13 +31,13 @@ def test_analyze(mock_data):
 def test_analyze_size_factors(mock_data):
     x = mock_data.x
     out = analyze(
-        x, 
+        x,
         features=[f"{i}" for i in range(1000)],
         options=AnalyzeOptions(
             log_norm_counts_options=LogNormCountsOptions(
                 size_factors=np.ones(x.shape[1])
             )
-        )
+        ),
     )
 
     assert (out.size_factors == np.ones(x.shape[1])).all()

--- a/tests/test_log_norm_counts.py
+++ b/tests/test_log_norm_counts.py
@@ -68,7 +68,7 @@ def test_log_norm_counts_matrix(mock_data):
 def test_log_norm_counts_size_factors(mock_data):
     x = mock_data.x
 
-    ref, sf = log_norm_counts(x, LogNormCountsOptions(with_size_factors = True))
+    ref, sf = log_norm_counts(x, LogNormCountsOptions(with_size_factors=True))
     assert isinstance(ref, da.DelayedArray)
     assert isinstance(sf, np.ndarray)
     assert sf.shape[0] == x.shape[1]

--- a/tests/test_log_norm_counts.py
+++ b/tests/test_log_norm_counts.py
@@ -63,3 +63,12 @@ def test_log_norm_counts_matrix(mock_data):
     out = log_norm_counts(x, LogNormCountsOptions(size_factors=sf, delayed=False))
     assert isinstance(out, np.ndarray)
     assert np.allclose(out[:, 0], ref[:, 0])
+
+
+def test_log_norm_counts_size_factors(mock_data):
+    x = mock_data.x
+
+    ref, sf = log_norm_counts(x, LogNormCountsOptions(with_size_factors = True))
+    assert isinstance(ref, da.DelayedArray)
+    assert isinstance(sf, np.ndarray)
+    assert sf.shape[0] == x.shape[1]


### PR DESCRIPTION
This greatly simplifies the analyze() code as it means that we don't have to call center_size_factors separately.