### PR TITLE
fork instead of spawn

### DIFF
--- a/src/scranpy/analyze/run_neighbor_suite.py
+++ b/src/scranpy/analyze/run_neighbor_suite.py
@@ -1,4 +1,5 @@
 from concurrent.futures import ProcessPoolExecutor, wait
+import multiprocessing
 from copy import copy
 from typing import Callable, Tuple
 
@@ -90,8 +91,9 @@ def run_neighbor_suite(
     # Attempting to evenly distribute threads across the tasks.  t-SNE and UMAP
     # are run on separate processes while the SNN graph construction is kept on
     # the main thread because we'll need the output for marker detection.
+    mp_context=multiprocessing.get_context("fork")
     threads_per_task = max(1, int(num_threads / 3))
-    executor = ProcessPoolExecutor(max_workers=min(2, num_threads))
+    executor = ProcessPoolExecutor(max_workers=min(2, num_threads), mp_context=mp_context)
     _tasks = []
 
     run_tsne_copy = copy(run_tsne_options)

--- a/src/scranpy/analyze/run_neighbor_suite.py
+++ b/src/scranpy/analyze/run_neighbor_suite.py
@@ -107,7 +107,6 @@ def run_neighbor_suite(
         pp = platform.platform()
         extra_args = {}
         if "macos" in pp.lower():
-
             extra_args["mp_context"] = mp.get_context("fork")
 
         executor = ProcessPoolExecutor(max_workers=max_workers, **extra_args)


### PR DESCRIPTION
Modifying the execution of neighborhood suite operations (computing t-SNE, UMAP, and SNN graph). When the package is run on macOS, we switch to "fork" to circumvent the need for `if __name__ == '__main__':` in user scripts. We completely avoid multiprocessing and execute all operations sequentially if the number of available threads is 1.

Trying to fix: #76 